### PR TITLE
Support serialising Schemes using Serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "material-color-utilities-rs"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license-file = "./LICENSE"
 description = "A rust port of Material Design color utilities"
@@ -10,6 +10,7 @@ repository = "https://github.com/alphaqu/material-color-utilities-rs"
 [dependencies]
 ahash = "0.8.0"
 lazy_static = "1.4.0"
+serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,11 @@
+//! Utilities for creating Material 3 colour schemes
+//!
+//! It has optional Serde serialisation support, using the `serde` feature.
+//!
+//! ```toml
+//! material-color-utilities-rs = {version = "0", features=["serde"]}
+//! ```
+
 pub mod blend;
 pub mod htc;
 pub mod palettes;

--- a/src/scheme.rs
+++ b/src/scheme.rs
@@ -38,7 +38,7 @@ pub struct Scheme {
     pub inverse_primary: [u8; 4],
 }
 
-#[cfg(feature="serde")]
+#[cfg(feature = "serde")]
 impl Serialize for Scheme {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -50,7 +50,7 @@ impl Serialize for Scheme {
         // the risk of a typo between a field name and it's name in the output.
         macro_rules! ser {
             ($key:ident) => {
-                state.serialize_field("$key", &format_argb_as_rgb(self.$key))?;
+                state.serialize_field(stringify!($key), &format_argb_as_rgb(self.$key))?;
             };
         }
 

--- a/src/scheme.rs
+++ b/src/scheme.rs
@@ -1,6 +1,11 @@
 use crate::palettes::core::CorePalette;
+#[cfg(feature = "serde")]
+use crate::util::color::format_argb_as_rgb;
+#[cfg(feature = "serde")]
+use serde::{ser::SerializeStruct, Serialize};
 
 /// Represents a Material color scheme, a mapping of color roles to colors.
+#[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
 pub struct Scheme {
     pub primary: [u8; 4],
     pub on_primary: [u8; 4],
@@ -31,6 +36,56 @@ pub struct Scheme {
     pub inverse_surface: [u8; 4],
     pub inverse_on_surface: [u8; 4],
     pub inverse_primary: [u8; 4],
+}
+
+#[cfg(feature="serde")]
+impl Serialize for Scheme {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("Scheme", 29)?;
+
+        // Macro to serialize an ARGB field to its RGB representation, and reduce
+        // the risk of a typo between a field name and it's name in the output.
+        macro_rules! ser {
+            ($key:ident) => {
+                state.serialize_field("$key", &format_argb_as_rgb(self.$key))?;
+            };
+        }
+
+        ser!(primary);
+        ser!(on_primary);
+        ser!(primary_container);
+        ser!(on_primary_container);
+        ser!(secondary);
+        ser!(on_secondary);
+        ser!(secondary_container);
+        ser!(on_secondary_container);
+        ser!(tertiary);
+        ser!(on_tertiary);
+        ser!(tertiary_container);
+        ser!(on_tertiary_container);
+        ser!(error);
+        ser!(on_error);
+        ser!(error_container);
+        ser!(on_error_container);
+        ser!(background);
+        ser!(on_background);
+        ser!(surface);
+        ser!(on_surface);
+        ser!(surface_variant);
+        ser!(on_surface_variant);
+        ser!(outline);
+        ser!(outline_variant);
+        ser!(shadow);
+        ser!(scrim);
+        ser!(inverse_surface);
+        ser!(inverse_on_surface);
+        ser!(inverse_primary);
+
+        state.end()
+    }
 }
 
 impl Scheme {

--- a/src/util/color.rs
+++ b/src/util/color.rs
@@ -27,6 +27,11 @@ pub fn argb_from_rgb(rgb: [u8; 3]) -> [u8; 4] {
     [255, rgb[0], rgb[1], rgb[2]]
 }
 
+/// Formats a color as ARGB to #RRGGBB format
+pub fn format_argb_as_rgb(argb: [u8; 4]) -> String {
+    format!("#{:02x}{:02x}{:02x}", argb[1], argb[2], argb[3])
+}
+
 /** Converts a color from linear RGB components to ARGB format. */
 pub fn argb_from_linrgb(linrgb: [f64; 3]) -> [u8; 4] {
     let r = delinearized(linrgb[0]);


### PR DESCRIPTION
Serde support is optional, using features.

Also, add other common derives to Scheme.