### PR TITLE
feat: implement quantize module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ repository = "https://github.com/alphaqu/material-color-utilities-rs"
 ahash = "0.8.0"
 lazy_static = "1.4.0"
 serde = { version = "1.0", optional = true, features = ["derive"] }
+rand = "0.8.5"
+num = "0.4"
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Rust Material color utilities
-#### A rust port of https://github.com/material-foundation/material-color-utilities
 
-Currently, everything is implemented except quantize module.
+#### A rust port of <https://github.com/material-foundation/material-color-utilities>
+
+Currently, everything is implemented.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 pub mod blend;
 pub mod htc;
 pub mod palettes;
-// TODO pub mod quantize;
+pub mod quantize;
 pub mod scheme;
 pub mod score;
 pub mod util;

--- a/src/quantize/lab_point_provider.rs
+++ b/src/quantize/lab_point_provider.rs
@@ -1,0 +1,39 @@
+use crate::util::color::{self, ARGB};
+
+use super::point_provider::{Point, PointProvider};
+
+pub struct LabPointProvider;
+
+impl LabPointProvider {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+/// Provides conversions needed for K-Means quantization. Converting input to
+/// points, and converting the final state of the K-Means algorithm to colors.
+impl PointProvider for LabPointProvider {
+    /// Convert a 3-element array to a color represented in ARGB.
+    fn to_int(&self, [l, a, b]: Point) -> ARGB {
+        color::argb_from_lab(l, a, b)
+    }
+
+    /// Convert a color represented in ARGB to a 3-element array of L*a*b*
+    /// coordinates of the color.
+    fn from_int(&self, argb: ARGB) -> Point {
+        color::lab_from_argb(argb)
+    }
+
+    /// Standard CIE 1976 delta E formula also takes the square root, unneeded
+    /// here. This method is used by quantization algorithms to compare distance,
+    /// and the relative ordering is the same, with or without a square root.
+    ///
+    /// This relatively minor optimization is helpful because this method is
+    /// called at least once for each pixel in an image.
+    fn distance(&self, from: Point, to: Point) -> f64 {
+        let l_diff = from[0] - to[0];
+        let a_diff = from[1] - to[1];
+        let b_diff = from[2] - to[2];
+        l_diff * l_diff + a_diff * a_diff + b_diff * b_diff
+    }
+}

--- a/src/quantize/mod.rs
+++ b/src/quantize/mod.rs
@@ -1,0 +1,6 @@
+mod lab_point_provider;
+mod point_provider;
+pub mod quantizer_celebi;
+pub mod quantizer_map;
+pub mod quantizer_wsmeans;
+pub mod quantizer_wu;

--- a/src/quantize/point_provider.rs
+++ b/src/quantize/point_provider.rs
@@ -1,0 +1,10 @@
+use crate::util::color::ARGB;
+
+pub type Point = [f64; 3];
+
+/// A trait allowing quantizers to use different color spaces.
+pub trait PointProvider {
+    fn to_int(&self, point: Point) -> ARGB;
+    fn from_int(&self, argb: ARGB) -> Point;
+    fn distance(&self, from: Point, to: Point) -> f64;
+}

--- a/src/quantize/quantizer_celebi.rs
+++ b/src/quantize/quantizer_celebi.rs
@@ -1,0 +1,92 @@
+use ahash::AHashMap;
+
+use crate::util::color::ARGB;
+
+use super::{quantizer_wsmeans::QuantizerWsmeans, quantizer_wu::QuantizerWu};
+
+/// An image quantizer that improves on the quality of a standard K-Means algorithm by setting the
+/// K-Means initial state to the output of a Wu quantizer, instead of random centroids. Improves on
+/// speed by several optimizations, as implemented in Wsmeans, or Weighted Square Means, K-Means with
+/// those optimizations.
+///
+/// This algorithm was designed by M. Emre Celebi, and was found in their 2011 paper, Improving
+/// the Performance of K-Means for Color Quantization.
+///
+/// https://arxiv.org/abs/1101.0395
+pub struct QuantizerCelebi;
+
+impl QuantizerCelebi {
+    /// Reduce the number of colors needed to represented the input, minimizing the difference
+    /// between the original image and the recolored image.
+    ///
+    /// # Arguments
+    ///
+    /// * `pixels` - Colors in ARGB format.
+    /// * `max_colors` - The number of colors to divide the image into. A lower number of colors
+    /// may be returned.
+    ///
+    /// # Returns
+    ///
+    /// Map with keys of colors in ARGB format, and values of number of pixels in the original
+    /// image that correspond to the color in the quantized image.
+    pub fn quantize(&mut self, pixels: &[ARGB], max_colors: usize) -> AHashMap<ARGB, u8> {
+        let mut quantizer_wu = QuantizerWu::new();
+        let colors = quantizer_wu.quantize(pixels, max_colors);
+
+        QuantizerWsmeans.quantize(pixels, &colors, max_colors)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const RED: ARGB = [0xff, 0xff, 0x00, 0x00];
+    const GREEN: ARGB = [0xff, 0x00, 0xff, 0x00];
+    const BLUE: ARGB = [0xff, 0x00, 0x00, 0xff];
+
+    #[test]
+    fn test_1r() {
+        let answer = QuantizerCelebi.quantize(&[RED], 128);
+        assert_eq!(answer.len(), 1);
+        assert_eq!(answer.get(&RED), Some(&1));
+    }
+
+    #[test]
+    fn test_1g() {
+        let answer = QuantizerCelebi.quantize(&[GREEN], 128);
+        assert_eq!(answer.len(), 1);
+        assert_eq!(answer.get(&GREEN), Some(&1));
+    }
+
+    #[test]
+    fn test_1b() {
+        let answer = QuantizerCelebi.quantize(&[BLUE], 128);
+        assert_eq!(answer.len(), 1);
+        assert_eq!(answer.get(&BLUE), Some(&1));
+    }
+
+    #[test]
+    fn test_5b() {
+        let answer = QuantizerCelebi.quantize(&[BLUE, BLUE, BLUE, BLUE, BLUE], 128);
+        assert_eq!(answer.len(), 1);
+        assert_eq!(answer.get(&BLUE), Some(&5));
+    }
+
+    #[test]
+    fn test_2r_3g() {
+        let answer = QuantizerCelebi.quantize(&[RED, RED, GREEN, GREEN, GREEN], 128);
+        assert_eq!(answer.len(), 2);
+        assert_eq!(answer.get(&RED), Some(&2));
+        assert_eq!(answer.get(&GREEN), Some(&3));
+    }
+
+    #[test]
+    fn test_1r_1g_1b() {
+        let answer = QuantizerCelebi.quantize(&[RED, GREEN, BLUE], 128);
+        assert_eq!(answer.len(), 3);
+        assert_eq!(answer.get(&RED), Some(&1));
+        assert_eq!(answer.get(&GREEN), Some(&1));
+        assert_eq!(answer.get(&BLUE), Some(&1));
+    }
+}

--- a/src/quantize/quantizer_map.rs
+++ b/src/quantize/quantizer_map.rs
@@ -1,0 +1,21 @@
+use crate::util::color::ARGB;
+use ahash::AHashMap;
+
+/// Creates a dictionary with keys of colors, and values of count of the color
+#[derive(Debug, Default, Clone)]
+pub struct QuantizerMap;
+
+impl QuantizerMap {
+    pub fn quantize(pixels: &[ARGB]) -> AHashMap<ARGB, u8> {
+        let mut pixel_by_count = AHashMap::new();
+
+        for pixel in pixels {
+            pixel_by_count
+                .entry(*pixel)
+                .and_modify(|count| *count += 1u8)
+                .or_insert(1);
+        }
+
+        pixel_by_count
+    }
+}

--- a/src/quantize/quantizer_wsmeans.rs
+++ b/src/quantize/quantizer_wsmeans.rs
@@ -1,0 +1,208 @@
+use ahash::AHashMap;
+
+use crate::util::color::ARGB;
+
+use super::{
+    lab_point_provider::LabPointProvider,
+    point_provider::{Point, PointProvider},
+};
+
+const MAX_ITERATIONS: u8 = 10;
+const MIN_MOVEMENT_DISTANCE: f64 = 3.0;
+
+/// An image quantizer that improves on the speed of a standard K-Means algorithm by implementing
+/// several optimizations, including deduping identical pixels and a triangle inequality rule that
+/// reduces the number of comparisons needed to identify which cluster a point should be moved to.
+///
+/// Wsmeans stands for Weighted Square Means.
+///
+/// This algorithm was designed by M. Emre Celebi, and was found in their 2011 paper, Improving
+/// the Performance of K-Means for Color Quantization. https://arxiv.org/abs/1101.0395
+pub struct QuantizerWsmeans;
+
+impl QuantizerWsmeans {
+    /// # Arguments
+    ///
+    /// * `input_pixels` - Colors in ARGB format.
+    /// * `starting_clusters` - Defines the initial state of the quantizer. Passing
+    /// an empty array is fine, the implementation will create its own initial
+    /// state that leads to reproducible results for the same inputs.
+    /// Passing an array that is the result of Wu quantization leads to higher
+    /// quality results.
+    /// * `max_colors` The number of colors to divide the image into. A lower
+    /// number of colors may be returned.
+    ///
+    /// # Returns
+    ///
+    /// Colors in ARGB format.
+    pub fn quantize(
+        &mut self,
+        input_pixels: &[ARGB],
+        starting_clusters: &[ARGB],
+        max_colors: usize,
+    ) -> AHashMap<ARGB, u8> {
+        let mut pixel_to_count: AHashMap<ARGB, u8> = AHashMap::new();
+        let mut points: Vec<Point> = Vec::with_capacity(input_pixels.len());
+        let mut pixels: Vec<ARGB> = Vec::with_capacity(input_pixels.len());
+        let point_provider = LabPointProvider::new();
+        let mut point_count = 0;
+        for input_pixel in input_pixels {
+            if let Some(pixel_count) = pixel_to_count.get(input_pixel) {
+                pixel_to_count.insert(*input_pixel, pixel_count + 1);
+            } else {
+                point_count += 1;
+                points.push(point_provider.from_int(*input_pixel));
+                pixels.push(*input_pixel);
+                pixel_to_count.insert(*input_pixel, 1);
+            }
+        }
+
+        let mut counts = vec![0u8; point_count];
+        for i in 0..point_count {
+            let pixel = pixels[i];
+            if let Some(count) = pixel_to_count.get(&pixel) {
+                counts[i] = *count;
+            }
+        }
+
+        let mut cluster_count = max_colors.min(point_count);
+        if starting_clusters.len() > 0 {
+            cluster_count = cluster_count.min(starting_clusters.len())
+        }
+
+        let mut clusters = Vec::from_iter(
+            starting_clusters
+                .iter()
+                .map(|cluster| point_provider.from_int(*cluster)),
+        );
+
+        let additional_clusters_needed = cluster_count - clusters.len();
+        if starting_clusters.len() == 0 && additional_clusters_needed > 0 {
+            for _ in 0..additional_clusters_needed {
+                let l = rand::random::<f64>() * 100.0;
+                let a = rand::random::<f64>() * (100.0 - (-100.0) + 1.0) + -100.0;
+                let b = rand::random::<f64>() * (100.0 - (-100.0) + 1.0) + -100.0;
+
+                clusters.push([l, a, b])
+            }
+        }
+
+        let mut cluster_indices = Vec::from_iter((0..point_count).map(|_| {
+            let index = rand::random::<f32>() * cluster_count as f32;
+            index.floor() as usize
+        }));
+
+        let mut index_matrix = Vec::from_iter((0..cluster_count).map(|_| vec![0; cluster_count]));
+
+        let mut distance_to_index_matrix = Vec::from_iter(
+            (0..cluster_count)
+                .map(|_| Vec::from_iter((0..cluster_count).map(|_| Distance::default()))),
+        );
+
+        let mut pixel_count_sums = vec![0; cluster_count];
+        for iteration in 0..MAX_ITERATIONS {
+            for i in 0..cluster_count {
+                for j in 0..cluster_count {
+                    let distance = point_provider.distance(clusters[i], clusters[j]);
+                    distance_to_index_matrix[j][i].distance = distance;
+                    distance_to_index_matrix[j][i].index = i;
+                    distance_to_index_matrix[i][j].distance = distance;
+                    distance_to_index_matrix[i][j].index = j;
+                }
+                // requires alternative sorting since f64 doesn't implement Ord
+                // https://doc.rust-lang.org/std/primitive.slice.html#method.sort_by
+                distance_to_index_matrix[i].sort_by(|a, b| a.partial_cmp(b).unwrap());
+                for j in 0..cluster_count {
+                    index_matrix[i][j] = distance_to_index_matrix[i][j].index;
+                }
+            }
+
+            let mut points_moved = 0usize;
+            for i in 0..point_count {
+                let point = points[i];
+                let previous_cluster_index = cluster_indices[i];
+                let previous_cluster = clusters[previous_cluster_index];
+                let previous_distance = point_provider.distance(point, previous_cluster);
+                let mut minimum_distance = previous_distance;
+                let mut new_cluster_index_option: Option<usize> = None;
+                for j in 0..cluster_count {
+                    let distance_index = distance_to_index_matrix[previous_cluster_index][j];
+                    if distance_index.distance >= 4.0 * previous_distance {
+                        continue;
+                    }
+                    let distance = point_provider.distance(point, clusters[j]);
+                    if distance < minimum_distance {
+                        minimum_distance = distance;
+                        new_cluster_index_option = Some(j);
+                    }
+                }
+                if let Some(new_cluster_index) = new_cluster_index_option {
+                    let distance_change =
+                        (minimum_distance.sqrt() - previous_distance.sqrt()).abs();
+                    if distance_change > MIN_MOVEMENT_DISTANCE {
+                        points_moved += 1;
+                        cluster_indices[i] = new_cluster_index;
+                    }
+                }
+            }
+
+            if points_moved == 0 && iteration != 0 {
+                break;
+            }
+
+            let component_sums = {
+                let mut component_sums: [Vec<f64>; 3] = [
+                    vec![0.0; cluster_count],
+                    vec![0.0; cluster_count],
+                    vec![0.0; cluster_count],
+                ];
+                for i in 0..point_count {
+                    let cluster_index = cluster_indices[i];
+                    let point = points[i];
+                    let count = counts[i];
+                    pixel_count_sums[cluster_index] += count;
+                    component_sums[0][cluster_index] += point[0] * count as f64;
+                    component_sums[1][cluster_index] += point[1] * count as f64;
+                    component_sums[2][cluster_index] += point[2] * count as f64;
+                }
+                component_sums
+            };
+
+            for i in 0..cluster_count {
+                let count = pixel_count_sums[i];
+                clusters[i] = if count == 0 {
+                    Default::default()
+                } else {
+                    [
+                        component_sums[0][i] / count as f64,
+                        component_sums[1][i] / count as f64,
+                        component_sums[2][i] / count as f64,
+                    ]
+                };
+            }
+        }
+
+        let mut argb_to_population = AHashMap::new();
+
+        for i in 0..cluster_count {
+            let count = pixel_count_sums[i];
+            if count == 0 {
+                continue;
+            }
+            let possible_new_cluster = point_provider.to_int(clusters[i]);
+            if argb_to_population.contains_key(&possible_new_cluster) {
+                continue;
+            }
+
+            argb_to_population.insert(possible_new_cluster, count);
+        }
+
+        argb_to_population
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, PartialOrd)]
+struct Distance {
+    index: usize,
+    distance: f64,
+}

--- a/src/quantize/quantizer_wu.rs
+++ b/src/quantize/quantizer_wu.rs
@@ -1,0 +1,507 @@
+use std::ops::{Add, Sub};
+
+use num::{traits::AsPrimitive, Num};
+
+use crate::util::color::ARGB;
+
+use super::quantizer_map::QuantizerMap;
+
+/// A histogram of all the input colors is constructed. It has the shape of a
+/// cube. The cube would be too large if it contained all 16 million colors:
+/// historical best practice is to use 5 bits  of the 8 in each channel,
+/// reducing the histogram to a volume of ~32,000.
+const INDEX_BITS: u8 = 5;
+const BITS_TO_REMOVE: u8 = 8 - INDEX_BITS;
+const SIDE_LENGTH: usize = 33; // ((1 << INDEX_BITS) + 1)
+const TOTAL_SIZE: usize = 35937; // INDEX_COUNT * INDEX_COUNT * INDEX_COUNT
+
+pub enum Direction {
+    Red,
+    Green,
+    Blue,
+}
+
+/// Represents requested and result counts of Wu algorithm.
+#[derive(Debug, Default, Clone)]
+pub struct QuantizerWuCounter {
+    /// How many colors the caller asked to be returned from quantization
+    pub requested_count: usize,
+    /// Actual number of colors achieved from quantization. May be lower than the requested count
+    pub result_count: usize,
+}
+
+impl QuantizerWuCounter {
+    pub fn new(requested_count: usize, result_count: usize) -> Self {
+        Self {
+            requested_count,
+            result_count,
+        }
+    }
+}
+
+/// Represents the result of calculating where to cut an existing box in such
+/// a way to maximize variance between the two new boxes created by a cut.
+#[derive(Debug, Default, Clone)]
+pub struct Maximized {
+    pub cut_location: Option<u8>,
+    pub maximum: f64,
+}
+
+impl Maximized {
+    pub fn new(cut_location: Option<u8>, maximum: f64) -> Self {
+        Self {
+            cut_location,
+            maximum,
+        }
+    }
+}
+
+/// An image quantizer that divides the image's pixels into clusters by recursively cutting an RGB
+/// cube, based on the weight of pixels in each area of the cube.
+///
+/// The algorithm was described by Xiaolin Wu in Graphic Gems II, published in 1991.
+#[derive(Debug)]
+pub struct QuantizerWu<T = u32> {
+    weights: Vec<T>,
+    moments_r: Vec<T>,
+    moments_g: Vec<T>,
+    moments_b: Vec<T>,
+    moments: Vec<f64>,
+    cubes: Vec<Box>,
+}
+
+fn get_index<T>(r: T, g: T, b: T) -> usize
+where
+    T: AsPrimitive<usize>,
+{
+    fn inner(r: usize, g: usize, b: usize) -> usize {
+        ((r << (INDEX_BITS * 2)) + (r << (INDEX_BITS + 1)) + r + (g << INDEX_BITS) + g + b).into()
+    }
+    inner(r.as_(), g.as_(), b.as_())
+}
+
+impl Default for QuantizerWu {
+    fn default() -> Self {
+        Self {
+            weights: vec![0; TOTAL_SIZE],
+            moments_r: vec![0; TOTAL_SIZE],
+            moments_g: vec![0; TOTAL_SIZE],
+            moments_b: vec![0; TOTAL_SIZE],
+            moments: vec![0.0; TOTAL_SIZE],
+            cubes: Default::default(),
+        }
+    }
+}
+
+impl QuantizerWu {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn quantize(&mut self, pixels: &[ARGB], max_colors: usize) -> Vec<ARGB> {
+        self.construct_histogram(pixels);
+        self.compute_moments();
+
+        let create_boxes_result = self.create_boxes(max_colors);
+        self.create_result(create_boxes_result.result_count)
+    }
+
+    fn construct_histogram(&mut self, pixels: &[ARGB]) {
+        self.weights = vec![0; TOTAL_SIZE];
+        self.moments_r = vec![0; TOTAL_SIZE];
+        self.moments_g = vec![0; TOTAL_SIZE];
+        self.moments_b = vec![0; TOTAL_SIZE];
+        self.moments = vec![0.0; TOTAL_SIZE];
+
+        let count_by_color = QuantizerMap::quantize(pixels);
+
+        for ([_, red, green, blue], count) in count_by_color {
+            let index = get_index(
+                (red >> BITS_TO_REMOVE) + 1,
+                (green >> BITS_TO_REMOVE) + 1,
+                (blue >> BITS_TO_REMOVE) + 1,
+            );
+
+            let (red, green, blue, count) = (red as u32, green as u32, blue as u32, count as u32);
+
+            self.weights[index] += count;
+            self.moments_r[index] += count * red;
+            self.moments_g[index] += count * green;
+            self.moments_b[index] += count * blue;
+
+            let amount: f64 = (count * (red * red + green * green + blue * blue)).into();
+            self.moments[index] += amount;
+        }
+    }
+
+    fn compute_moments(&mut self) {
+        for r in 1..SIDE_LENGTH {
+            let mut area = [0; SIDE_LENGTH];
+            let mut area_r = [0; SIDE_LENGTH];
+            let mut area_g = [0; SIDE_LENGTH];
+            let mut area_b = [0; SIDE_LENGTH];
+            let mut area2 = [0.0; SIDE_LENGTH];
+
+            for g in 1..SIDE_LENGTH {
+                let mut line = 0;
+                let mut line_r = 0;
+                let mut line_g = 0;
+                let mut line_b = 0;
+                let mut line2 = 0.0;
+
+                for b in 1..SIDE_LENGTH {
+                    let index = get_index(r, g, b);
+                    line += self.weights[index];
+                    line_r += self.moments_r[index];
+                    line_g += self.moments_g[index];
+                    line_b += self.moments_b[index];
+                    line2 += self.moments[index];
+
+                    area[b] += line;
+                    area_r[b] += line_r;
+                    area_g[b] += line_g;
+                    area_b[b] += line_b;
+                    area2[b] += line2;
+
+                    let previous_index = get_index(r - 1, g, b);
+                    self.weights[index] = self.weights[previous_index] + area[b];
+                    self.moments_r[index] = self.moments_r[previous_index] + area_r[b];
+                    self.moments_g[index] = self.moments_g[previous_index] + area_g[b];
+                    self.moments_b[index] = self.moments_b[previous_index] + area_b[b];
+                    self.moments[index] = self.moments[previous_index] + area2[b];
+                }
+            }
+        }
+    }
+
+    fn create_boxes(&mut self, max_colors: usize) -> QuantizerWuCounter {
+        self.cubes = vec![Box::default(); max_colors];
+        let mut volume_variance = vec![0.0; max_colors];
+
+        let len: u8 = SIDE_LENGTH.try_into().unwrap();
+        let max_index = len - 1;
+        self.cubes[0].pixels = (
+            Pixel::new(0, 0, 0),
+            Pixel::new(max_index, max_index, max_index),
+        );
+
+        let mut generated_color_count = max_colors;
+        let mut next_index = 0usize;
+        let mut index = 1usize;
+        while index < max_colors {
+            if self.cut(next_index, index) {
+                let next_cube = &self.cubes[next_index];
+                volume_variance[next_index] = if next_cube.vol > 1 {
+                    self.variance(next_cube)
+                } else {
+                    0.0
+                };
+
+                let current_cube = &self.cubes[index];
+                volume_variance[index] = if current_cube.vol > 1 {
+                    self.variance(current_cube)
+                } else {
+                    0.0
+                };
+            } else {
+                volume_variance[next_index] = 0.0;
+                index -= 1;
+            };
+
+            next_index = 0;
+            let mut temp = volume_variance[0];
+            for j in 1..=index {
+                if volume_variance[j] > temp {
+                    temp = volume_variance[j];
+                    next_index = j;
+                }
+            }
+            if temp <= 0.0 {
+                generated_color_count = index + 1;
+                break;
+            }
+
+            index += 1;
+        }
+
+        QuantizerWuCounter::new(max_colors, generated_color_count)
+    }
+
+    fn create_result(&self, color_count: usize) -> Vec<ARGB> {
+        Vec::from_iter((0..color_count).filter_map(|i| {
+            let cube = &self.cubes[i];
+            let weight = self.volume(&cube, &self.weights);
+
+            if weight == 0 {
+                return None;
+            }
+
+            let r = self.volume(&cube, &self.moments_r) / weight;
+            let g = self.volume(&cube, &self.moments_g) / weight;
+            let b = self.volume(&cube, &self.moments_b) / weight;
+
+            Some([0xff, r as u8, g as u8, b as u8])
+        }))
+    }
+
+    fn variance(&self, cube: &Box) -> f64 {
+        let dr = self.volume(cube, &self.moments_r);
+        let dg = self.volume(cube, &self.moments_g);
+        let db = self.volume(cube, &self.moments_b);
+        let xx = self.volume(cube, &self.moments);
+
+        let hypotenuse: f64 = (dr * dr + dg * dg + db * db).into();
+        let volume: f64 = self.volume(cube, &self.weights).into();
+
+        xx - (hypotenuse / volume)
+    }
+
+    fn cut(&mut self, next_index: usize, current_index: usize) -> bool {
+        let (mut one, mut two) = (
+            self.cubes[next_index].clone(),
+            self.cubes[current_index].clone(),
+        );
+
+        let whole_r = self.volume(&one, &self.moments_r);
+        let whole_g = self.volume(&one, &self.moments_g);
+        let whole_b = self.volume(&one, &self.moments_b);
+        let whole_w = self.volume(&one, &self.weights);
+
+        let max_r_result = self.maximize(
+            &one,
+            Direction::Red,
+            one.pixels.0.r + 1,
+            one.pixels.1.r,
+            whole_r,
+            whole_g,
+            whole_b,
+            whole_w,
+        );
+        let max_g_result = self.maximize(
+            &one,
+            Direction::Green,
+            one.pixels.0.g + 1,
+            one.pixels.1.g,
+            whole_r,
+            whole_g,
+            whole_b,
+            whole_w,
+        );
+        let max_b_result = self.maximize(
+            &one,
+            Direction::Blue,
+            one.pixels.0.b + 1,
+            one.pixels.1.b,
+            whole_r,
+            whole_g,
+            whole_b,
+            whole_w,
+        );
+
+        let max_r = max_r_result.maximum;
+        let max_g = max_g_result.maximum;
+        let max_b = max_b_result.maximum;
+
+        let direction = {
+            if max_r >= max_g && max_r >= max_b {
+                if max_r_result.cut_location.is_none() {
+                    return false;
+                }
+                Direction::Red
+            } else if max_g >= max_r && max_g >= max_b {
+                Direction::Green
+            } else {
+                Direction::Blue
+            }
+        };
+
+        two.pixels.1 = one.pixels.1.clone();
+
+        match direction {
+            Direction::Red => {
+                one.pixels.1.r = max_r_result.cut_location.unwrap_or_default();
+                two.pixels.0.r = one.pixels.1.r;
+                two.pixels.0.g = one.pixels.0.g;
+                two.pixels.0.b = one.pixels.0.b;
+            }
+            Direction::Green => {
+                one.pixels.1.g = max_g_result.cut_location.unwrap_or_default();
+                two.pixels.0.r = one.pixels.0.r;
+                two.pixels.0.g = one.pixels.1.g;
+                two.pixels.0.b = one.pixels.0.b;
+            }
+            Direction::Blue => {
+                one.pixels.1.b = max_b_result.cut_location.unwrap_or_default();
+                two.pixels.0.r = one.pixels.0.r;
+                two.pixels.0.g = one.pixels.0.g;
+                two.pixels.0.b = one.pixels.1.b;
+            }
+        }
+
+        one.vol = one.calculate_vol();
+        two.vol = two.calculate_vol();
+
+        self.cubes[next_index] = one;
+        self.cubes[current_index] = two;
+
+        true
+    }
+
+    fn maximize(
+        &self,
+        cube: &Box,
+        direction: Direction,
+        first: u8,
+        last: u8,
+        whole_r: u32,
+        whole_g: u32,
+        whole_b: u32,
+        whole_w: u32,
+    ) -> Maximized {
+        let bottom_r = self.bottom(cube, &direction, &self.moments_r);
+        let bottom_g = self.bottom(cube, &direction, &self.moments_g);
+        let bottom_b = self.bottom(cube, &direction, &self.moments_b);
+        let bottom_w = self.bottom(cube, &direction, &self.weights);
+
+        let mut max = 0.0;
+        let mut cut = Option::<u8>::None;
+
+        let mut half_r;
+        let mut half_g;
+        let mut half_b;
+        let mut half_w;
+
+        for i in first..last {
+            half_r = bottom_r + self.top(cube, &direction, i, &self.moments_r);
+            half_g = bottom_g + self.top(cube, &direction, i, &self.moments_g);
+            half_b = bottom_b + self.top(cube, &direction, i, &self.moments_b);
+            half_w = bottom_w + self.top(cube, &direction, i, &self.weights);
+            if half_w == 0 {
+                continue;
+            }
+
+            let temp_numerator: f64 = (half_r * half_r + half_g * half_g + half_b * half_b).into();
+            let temp_denominator: f64 = half_w.into();
+            let temp = temp_numerator / temp_denominator;
+
+            half_r = whole_r - half_r;
+            half_g = whole_g - half_g;
+            half_b = whole_b - half_b;
+            half_w = whole_w - half_w;
+            if half_w == 0 {
+                continue;
+            }
+
+            let temp_numerator: f64 = (half_r * half_r + half_g * half_g + half_b * half_b).into();
+            let temp_denominator: f64 = half_w.into();
+            let temp = temp + (temp_numerator / temp_denominator);
+
+            if temp > max {
+                max = temp;
+                cut = Some(i)
+            }
+        }
+
+        Maximized::new(cut, max)
+    }
+
+    fn volume<T>(&self, cube: &Box, moment: &Vec<T>) -> T
+    where
+        T: Copy + Num,
+    {
+        let (pixel0, pixel1) = &cube.pixels;
+        moment[get_index(pixel1.r, pixel1.g, pixel1.b)]
+            - moment[get_index(pixel1.r, pixel1.g, pixel0.b)]
+            - moment[get_index(pixel1.r, pixel0.g, pixel1.b)]
+            + moment[get_index(pixel1.r, pixel0.g, pixel0.b)]
+            - moment[get_index(pixel0.r, pixel1.g, pixel1.b)]
+            + moment[get_index(pixel0.r, pixel1.g, pixel0.b)]
+            + moment[get_index(pixel0.r, pixel0.g, pixel1.b)]
+            - moment[get_index(pixel0.r, pixel0.g, pixel0.b)]
+    }
+
+    fn bottom<T>(&self, cube: &Box, direction: &Direction, moment: &Vec<T>) -> T
+    where
+        T: Copy + Add<Output = T> + Sub<Output = T>,
+    {
+        match direction {
+            Direction::Red => {
+                moment[get_index(cube.pixels.0.r, cube.pixels.1.g, cube.pixels.0.b)]
+                    + moment[get_index(cube.pixels.0.r, cube.pixels.0.g, cube.pixels.1.b)]
+                    - moment[get_index(cube.pixels.0.r, cube.pixels.0.g, cube.pixels.0.b)]
+                    - moment[get_index(cube.pixels.0.r, cube.pixels.1.g, cube.pixels.1.b)]
+            }
+            Direction::Green => {
+                moment[get_index(cube.pixels.1.r, cube.pixels.0.g, cube.pixels.0.b)]
+                    + moment[get_index(cube.pixels.0.r, cube.pixels.0.g, cube.pixels.1.b)]
+                    - moment[get_index(cube.pixels.0.r, cube.pixels.0.g, cube.pixels.0.b)]
+                    - moment[get_index(cube.pixels.1.r, cube.pixels.0.g, cube.pixels.1.b)]
+            }
+            Direction::Blue => {
+                moment[get_index(cube.pixels.1.r, cube.pixels.0.g, cube.pixels.0.b)]
+                    + moment[get_index(cube.pixels.0.r, cube.pixels.1.g, cube.pixels.0.b)]
+                    - moment[get_index(cube.pixels.0.r, cube.pixels.0.g, cube.pixels.0.b)]
+                    - moment[get_index(cube.pixels.1.r, cube.pixels.1.g, cube.pixels.0.b)]
+            }
+        }
+    }
+
+    fn top<T>(&self, cube: &Box, direction: &Direction, position: u8, moment: &Vec<T>) -> T
+    where
+        T: Copy + Add<Output = T> + Sub<Output = T>,
+    {
+        match direction {
+            Direction::Red => {
+                moment[get_index(position, cube.pixels.1.g, cube.pixels.1.b)]
+                    - moment[get_index(position, cube.pixels.1.g, cube.pixels.0.b)]
+                    - moment[get_index(position, cube.pixels.0.g, cube.pixels.1.b)]
+                    + moment[get_index(position, cube.pixels.0.g, cube.pixels.0.b)]
+            }
+            Direction::Green => {
+                moment[get_index(cube.pixels.1.r, position, cube.pixels.1.b)]
+                    - moment[get_index(cube.pixels.1.r, position, cube.pixels.0.b)]
+                    - moment[get_index(cube.pixels.0.r, position, cube.pixels.1.b)]
+                    + moment[get_index(cube.pixels.0.r, position, cube.pixels.0.b)]
+            }
+            Direction::Blue => {
+                moment[get_index(cube.pixels.1.r, cube.pixels.1.g, position)]
+                    - moment[get_index(cube.pixels.1.r, cube.pixels.0.g, position)]
+                    - moment[get_index(cube.pixels.0.r, cube.pixels.1.g, position)]
+                    + moment[get_index(cube.pixels.0.r, cube.pixels.0.g, position)]
+            }
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Pixel {
+    pub r: u8,
+    pub g: u8,
+    pub b: u8,
+}
+
+impl Pixel {
+    pub fn new(r: u8, g: u8, b: u8) -> Self {
+        Self { r, g, b }
+    }
+}
+
+/// Keeps track of the state of each box created as the Wu quantization
+/// algorithm progresses through, dividing the image's pixels as plotted in RGB.
+#[derive(Debug, Default, Clone)]
+pub struct Box {
+    pub pixels: (Pixel, Pixel),
+    pub vol: u16,
+}
+
+impl Box {
+    pub fn new(pixels: (Pixel, Pixel)) -> Self {
+        Self { vol: 0, pixels }
+    }
+
+    pub fn calculate_vol(&self) -> u16 {
+        (self.pixels.1.r - self.pixels.0.r) as u16
+            * (self.pixels.1.g - self.pixels.0.g) as u16
+            * (self.pixels.1.b - self.pixels.0.b) as u16
+    }
+}


### PR DESCRIPTION
This PR contains all the code for the quantize module that I ported from the other implementations. The tests located in `quantizer_celebi.rs` were the only ones I saw for the quantizer module in other implementations. All 6 are passing. The implementation could be improved and I think it could use more tests, but it falls in line with the others.

I added 2 dependencies:

1. `rand` - There are a few parts of the quantizer that require generating random values. Using the `rand` crate seems to be the defacto way to do that in Rust, as far as I know.
2. `num` - Great for writing generic numeric functions. Could live without, but I'd prefer to keep it. Could suffice with slimming down to `num_traits` because that is all I import from.

If you have any issues with these, let me know and we can figure it out from there.