### PR TITLE
Fix overflows in quantize module

### DIFF
--- a/src/quantize/quantizer_celebi.rs
+++ b/src/quantize/quantizer_celebi.rs
@@ -29,7 +29,7 @@ impl QuantizerCelebi {
     ///
     /// Map with keys of colors in ARGB format, and values of number of pixels in the original
     /// image that correspond to the color in the quantized image.
-    pub fn quantize(&mut self, pixels: &[ARGB], max_colors: usize) -> AHashMap<ARGB, u8> {
+    pub fn quantize(&mut self, pixels: &[ARGB], max_colors: usize) -> AHashMap<ARGB, u32> {
         let mut quantizer_wu = QuantizerWu::new();
         let colors = quantizer_wu.quantize(pixels, max_colors);
 

--- a/src/quantize/quantizer_map.rs
+++ b/src/quantize/quantizer_map.rs
@@ -6,13 +6,13 @@ use ahash::AHashMap;
 pub struct QuantizerMap;
 
 impl QuantizerMap {
-    pub fn quantize(pixels: &[ARGB]) -> AHashMap<ARGB, u8> {
+    pub fn quantize(pixels: &[ARGB]) -> AHashMap<ARGB, u32> {
         let mut pixel_by_count = AHashMap::new();
 
         for pixel in pixels {
             pixel_by_count
                 .entry(*pixel)
-                .and_modify(|count| *count += 1u8)
+                .and_modify(|count| *count += 1)
                 .or_insert(1);
         }
 

--- a/src/quantize/quantizer_wsmeans.rs
+++ b/src/quantize/quantizer_wsmeans.rs
@@ -40,8 +40,8 @@ impl QuantizerWsmeans {
         input_pixels: &[ARGB],
         starting_clusters: &[ARGB],
         max_colors: usize,
-    ) -> AHashMap<ARGB, u8> {
-        let mut pixel_to_count: AHashMap<ARGB, u8> = AHashMap::new();
+    ) -> AHashMap<ARGB, u32> {
+        let mut pixel_to_count: AHashMap<ARGB, u32> = AHashMap::new();
         let mut points: Vec<Point> = Vec::with_capacity(input_pixels.len());
         let mut pixels: Vec<ARGB> = Vec::with_capacity(input_pixels.len());
         let point_provider = LabPointProvider::new();
@@ -57,7 +57,7 @@ impl QuantizerWsmeans {
             }
         }
 
-        let mut counts = vec![0u8; point_count];
+        let mut counts = vec![0u32; point_count];
         for i in 0..point_count {
             let pixel = pixels[i];
             if let Some(count) = pixel_to_count.get(&pixel) {

--- a/src/quantize/quantizer_wu.rs
+++ b/src/quantize/quantizer_wu.rs
@@ -175,8 +175,8 @@ impl QuantizerWu {
     }
 
     fn create_boxes(&mut self, max_colors: usize) -> QuantizerWuCounter {
-        self.cubes = vec![Box::default(); max_colors as usize];
-        let mut volume_variance = vec![0.0; max_colors as usize];
+        self.cubes = vec![Box::default(); max_colors];
+        let mut volume_variance = vec![0.0; max_colors];
 
         let len: u8 = SIDE_LENGTH.try_into().unwrap();
         let max_index = len - 1;
@@ -188,7 +188,7 @@ impl QuantizerWu {
         let mut generated_color_count = max_colors;
         let mut next_index = 0usize;
         let mut index = 1usize;
-        while index < max_colors as usize {
+        while index < max_colors {
             if self.cut(next_index, index) {
                 let next_cube = &self.cubes[next_index];
                 volume_variance[next_index] = if next_cube.vol > 1 {

--- a/src/quantize/quantizer_wu.rs
+++ b/src/quantize/quantizer_wu.rs
@@ -250,7 +250,8 @@ impl QuantizerWu {
         let db = self.volume(cube, &self.moments_b);
         let xx = self.volume(cube, &self.moments);
 
-        let hypotenuse: f64 = (dr * dr + dg * dg + db * db).into();
+        let (dr, dg, db) = (dr as f64, dg as f64, db as f64);
+        let hypotenuse = dr * dr + dg * dg + db * db;
         let volume: f64 = self.volume(cube, &self.weights).into();
 
         xx - (hypotenuse / volume)
@@ -380,7 +381,9 @@ impl QuantizerWu {
                 continue;
             }
 
-            let temp_numerator: f64 = (half_r * half_r + half_g * half_g + half_b * half_b).into();
+            let temp_numerator: f64 = (half_r as f64) * (half_r as f64)
+                + (half_g as f64) * (half_g as f64)
+                + (half_b as f64) * (half_b as f64);
             let temp_denominator: f64 = half_w.into();
             let temp = temp_numerator / temp_denominator;
 
@@ -392,7 +395,9 @@ impl QuantizerWu {
                 continue;
             }
 
-            let temp_numerator: f64 = (half_r * half_r + half_g * half_g + half_b * half_b).into();
+            let temp_numerator: f64 = (half_r as f64) * (half_r as f64)
+                + (half_g as f64) * (half_g as f64)
+                + (half_b as f64) * (half_b as f64);
             let temp_denominator: f64 = half_w.into();
             let temp = temp + (temp_numerator / temp_denominator);
 

--- a/src/quantize/quantizer_wu.rs
+++ b/src/quantize/quantizer_wu.rs
@@ -129,7 +129,7 @@ impl QuantizerWu {
             self.moments_g[index] += count * green;
             self.moments_b[index] += count * blue;
 
-            let amount: f64 = (count * (red * red + green * green + blue * blue)).into();
+            let amount: f64 = (count as f64) * ((red * red + green * green + blue * blue) as f64);
             self.moments[index] += amount;
         }
     }

--- a/src/score.rs
+++ b/src/score.rs
@@ -2,7 +2,6 @@ use crate::htc::cam16::Cam16;
 use crate::util::color::lstar_from_argb;
 use crate::util::math::{difference_degrees, sanitize_degrees_int};
 use ahash::AHashMap;
-use std::collections::HashMap;
 
 const CUTOFF_CHROMA: f64 = 15.0;
 const CUTOFF_EXCITED_PROPORTION: f64 = 0.01;
@@ -12,7 +11,7 @@ const WEIGHT_PROPORTION: f64 = 0.7;
 const WEIGHT_CHROMA_ABOVE: f64 = 0.3;
 const WEIGHT_CHROMA_BELOW: f64 = 0.1;
 
-pub fn score(colors_to_population: &HashMap<[u8; 4], u32>) -> Vec<[u8; 4]> {
+pub fn score(colors_to_population: &AHashMap<[u8; 4], u32>) -> Vec<[u8; 4]> {
     // Determine the total count of all colors.
     let mut population_sum = 0.0;
     for population in colors_to_population.values() {
@@ -136,15 +135,11 @@ mod tests {
 
     #[test]
     fn priority_test() {
-        let ranked = score(
-            &HashMap::from(
-                [
-                    ([0xff, 0xff, 0x00, 0x00], 1),
-                    ([0xff, 0x00, 0xff, 0x00], 1),
-                    ([0xff, 0x00, 0x00, 0xff], 1)
-                ]
-            )
-        );
+        let ranked = score(&AHashMap::from([
+            ([0xff, 0xff, 0x00, 0x00], 1),
+            ([0xff, 0x00, 0xff, 0x00], 1),
+            ([0xff, 0x00, 0x00, 0xff], 1),
+        ]));
 
         assert_eq!(ranked[0], [0xff, 0xff, 0x00, 0x00]);
         assert_eq!(ranked[1], [0xff, 0x00, 0xff, 0x00]);


### PR DESCRIPTION
`quantize` module panics when handling a `1600x1600` image. Though it would not panic in release builds, the result might be incorrect.

This pull request resolved this issue by converting types earlier(u32 -> f64, then multiply, otherwises u32*u32 might overflow) and use signed integers as C++ version does(negative number might occur).