### PR TITLE
various improvements to usability through changes to types

### DIFF
--- a/src/quantize/quantizer_celebi.rs
+++ b/src/quantize/quantizer_celebi.rs
@@ -29,7 +29,7 @@ impl QuantizerCelebi {
     ///
     /// Map with keys of colors in ARGB format, and values of number of pixels in the original
     /// image that correspond to the color in the quantized image.
-    pub fn quantize(&mut self, pixels: &[ARGB], max_colors: usize) -> AHashMap<ARGB, u8> {
+    pub fn quantize(&mut self, pixels: &[ARGB], max_colors: usize) -> AHashMap<ARGB, u32> {
         let mut quantizer_wu = QuantizerWu::new();
         let colors = quantizer_wu.quantize(pixels, max_colors);
 

--- a/src/quantize/quantizer_map.rs
+++ b/src/quantize/quantizer_map.rs
@@ -6,13 +6,13 @@ use ahash::AHashMap;
 pub struct QuantizerMap;
 
 impl QuantizerMap {
-    pub fn quantize(pixels: &[ARGB]) -> AHashMap<ARGB, u8> {
+    pub fn quantize(pixels: &[ARGB]) -> AHashMap<ARGB, u32> {
         let mut pixel_by_count = AHashMap::new();
 
         for pixel in pixels {
             pixel_by_count
                 .entry(*pixel)
-                .and_modify(|count| *count += 1u8)
+                .and_modify(|count| *count += 1)
                 .or_insert(1);
         }
 

--- a/src/quantize/quantizer_wsmeans.rs
+++ b/src/quantize/quantizer_wsmeans.rs
@@ -40,8 +40,8 @@ impl QuantizerWsmeans {
         input_pixels: &[ARGB],
         starting_clusters: &[ARGB],
         max_colors: usize,
-    ) -> AHashMap<ARGB, u8> {
-        let mut pixel_to_count: AHashMap<ARGB, u8> = AHashMap::new();
+    ) -> AHashMap<ARGB, u32> {
+        let mut pixel_to_count: AHashMap<ARGB, u32> = AHashMap::new();
         let mut points: Vec<Point> = Vec::with_capacity(input_pixels.len());
         let mut pixels: Vec<ARGB> = Vec::with_capacity(input_pixels.len());
         let point_provider = LabPointProvider::new();
@@ -57,7 +57,7 @@ impl QuantizerWsmeans {
             }
         }
 
-        let mut counts = vec![0u8; point_count];
+        let mut counts = vec![0; point_count];
         for i in 0..point_count {
             let pixel = pixels[i];
             if let Some(count) = pixel_to_count.get(&pixel) {

--- a/src/score.rs
+++ b/src/score.rs
@@ -2,7 +2,6 @@ use crate::htc::cam16::Cam16;
 use crate::util::color::lstar_from_argb;
 use crate::util::math::{difference_degrees, sanitize_degrees_int};
 use ahash::AHashMap;
-use std::collections::HashMap;
 
 const CUTOFF_CHROMA: f64 = 15.0;
 const CUTOFF_EXCITED_PROPORTION: f64 = 0.01;
@@ -12,7 +11,9 @@ const WEIGHT_PROPORTION: f64 = 0.7;
 const WEIGHT_CHROMA_ABOVE: f64 = 0.3;
 const WEIGHT_CHROMA_BELOW: f64 = 0.1;
 
-pub fn score(colors_to_population: &HashMap<[u8; 4], u32>) -> Vec<[u8; 4]> {
+// TODO: it would be best for this to accept generic hash maps
+// but idk how to do that
+pub fn score(colors_to_population: &AHashMap<[u8; 4], u32>) -> Vec<[u8; 4]> {
     // Determine the total count of all colors.
     let mut population_sum = 0.0;
     for population in colors_to_population.values() {
@@ -136,15 +137,11 @@ mod tests {
 
     #[test]
     fn priority_test() {
-        let ranked = score(
-            &HashMap::from(
-                [
-                    ([0xff, 0xff, 0x00, 0x00], 1),
-                    ([0xff, 0x00, 0xff, 0x00], 1),
-                    ([0xff, 0x00, 0x00, 0xff], 1)
-                ]
-            )
-        );
+        let ranked = score(&AHashMap::from([
+            ([0xff, 0xff, 0x00, 0x00], 1),
+            ([0xff, 0x00, 0xff, 0x00], 1),
+            ([0xff, 0x00, 0x00, 0xff], 1),
+        ]));
 
         assert_eq!(ranked[0], [0xff, 0xff, 0x00, 0x00]);
         assert_eq!(ranked[1], [0xff, 0x00, 0xff, 0x00]);


### PR DESCRIPTION
These are breaking changes in general, but
1. allow you to use the library for arbitrary images
2. greatly improve the internal consistency of types.

Note that this includes a `.clone` of the vector in `quantizer_wu.rs`, line 117. This likely has major performance implications, but I'm not sure how to resolve it.

It also has a slight issue in `score.rs`, line 16, where this function should really accept any hashmap-like type (including stdlib's or ahash), but I'm not sure how to resolve that either.

All tests pass otherwise.